### PR TITLE
Allow any string to be used as a color

### DIFF
--- a/src/bulma.tsx
+++ b/src/bulma.tsx
@@ -42,9 +42,7 @@ export declare namespace Bulma {
         isLoading?: boolean;
     }
 
-    export type Colors = 'white' | 'light' | 'dark' | 'black' | 'primary' | 'info' | 'success' | 'warning' | 'danger';
     export interface Color {
-        isColor?: Colors;
     }
 
     export type HeadingSizes = 1 | 2 | 3 | 4 | 5 | 6;
@@ -107,7 +105,7 @@ export declare namespace Bulma {
         isUnselectable?: boolean;
 
         hasTextAlign?: Alignments | 'centered';
-        hasTextColor?: Colors;
+        hasTextColor?: string;
     }
 
     export interface Modifiers extends
@@ -146,18 +144,6 @@ export const isCentered = is({ centered: true });
 
 export const isCenter = is({ center: true });
 export const isFullWidth = is({ fullwidth: true });
-
-const isColor = is({
-    black: true,
-    danger: true,
-    dark: true,
-    info: true,
-    light: true,
-    primary: true,
-    success: true,
-    warning: true,
-    white: true,
-});
 
 const isSmall = is({ small: true });
 const isMedium = is({ medium: true });
@@ -259,15 +245,12 @@ export function removeLoadingProps(props: Bulma.Loading) {
     return rest;
 }
 
-export function getColorModifiers({ isColor: color }: Bulma.Color) {
-    return isColor(color) ? { [`is-${color}`]: true } : {};
+export function getColorModifiers(color: Bulma.Color) {
+    return { [`is-${color}`]: true };
 }
 
 export function removeColorProps(props: Bulma.Color) {
-    const {
-        isColor,
-        ...rest } = props;
-    return rest;
+    return props;
 }
 
 const isValidHeading = isBetween(1, 6);
@@ -330,7 +313,7 @@ const getAlignModifier = (modifier: string, helper: string) => {
 };
 
 const getColorModifier = (modifier: string) => {
-    return isColor(modifier) ? { [`has-text-${modifier}`]: true } : {};
+    return  { [`has-text-${modifier}`]: true };
 };
 
 function getHelpersModifiers(

--- a/src/bulma.tsx
+++ b/src/bulma.tsx
@@ -43,6 +43,7 @@ export declare namespace Bulma {
     }
 
     export interface Color {
+        isColor?: string
     }
 
     export type HeadingSizes = 1 | 2 | 3 | 4 | 5 | 6;
@@ -245,12 +246,15 @@ export function removeLoadingProps(props: Bulma.Loading) {
     return rest;
 }
 
-export function getColorModifiers(color: Bulma.Color) {
-    return { [`is-${color}`]: true };
+export function getColorModifiers({ isColor: color }: Bulma.Color) {
+    return color ? { [`is-${color}`]: true } : {};
 }
 
 export function removeColorProps(props: Bulma.Color) {
-    return props;
+    const {
+        isColor,
+        ...rest } = props;
+    return rest;
 }
 
 const isValidHeading = isBetween(1, 6);

--- a/src/bulma.tsx
+++ b/src/bulma.tsx
@@ -317,7 +317,7 @@ const getAlignModifier = (modifier: string, helper: string) => {
 };
 
 const getColorModifier = (modifier: string) => {
-    return  { [`has-text-${modifier}`]: true };
+    return modifier ? { [`has-text-${modifier}`]: true } : {};
 };
 
 function getHelpersModifiers(


### PR DESCRIPTION
@AlgusDark been busy at work, but here's my first set of changes. Is this along the lines of what you were thinking? Still learning how typescript works, so some of this might not make sense 😅 

I'm a bit unsure whether the Color interface should be kept around since it is equivalent to a string now, besides intellisense help.

We might be able to entirely remove the `removeColorProps` function as well.

Also, many tests around individual components are broken, but only give me 
```
expect(received).toBe(expected)

    Expected value to be (using ===):
      true
    Received:
      false
```
I'm not sure what to do about fixing them, do you have a suggestion, perhaps how to print/debug how components are rendered? I have a feeling the issue is very simple and fixing one will fix them all.