### PR TITLE
Add ability to pass children to Icon

### DIFF
--- a/src/elements/Icon.tsx
+++ b/src/elements/Icon.tsx
@@ -17,7 +17,7 @@ export interface Icon<T> extends Bulma.Size, Bulma.Alignment,
 
 const isAlignOption = isOption(isLeft, isRight);
 
-export function Icon({children, ...props }: Icon<HTMLElement>) {
+export function Icon({ children, ...props }: Icon<HTMLElement>) {
     const className = classNames(
         'icon',
         {
@@ -30,7 +30,7 @@ export function Icon({children, ...props }: Icon<HTMLElement>) {
 
     const icon = (
         <span {...HTMLProps} className={className}>
-            <i className={`${props.className}`} aria-hidden="true"></i>
+            {children ? children : (<i className={`${props.className}`} aria-hidden="true"></i>)}
         </span>
     );
 

--- a/test/elements/Icon.test.tsx
+++ b/test/elements/Icon.test.tsx
@@ -44,4 +44,13 @@ describe('Icon', () => {
             </span>
         )).toBe(true);
     });
+
+    it('should render children instead of icon', () => {
+        const component = shallow(<Icon><span>child</span></Icon>)
+        expect(component.contains(
+            <span className='icon'>
+               <span>child</span>
+            </span>
+        )).toBe(true);
+    })
 });


### PR DESCRIPTION
I use bloomer and also the react fontawesome library.

I was using an older version of bloomer that accepted children for the Icon component.  I noticed that it was changed in a previous commit and was hoping it could be added back.  Let me know what you think.  

Thanks for this fantastic library.  :)

Here is an example of how I use it.

```
<Icon isAlign="left">
  <FontAwesomeIcon icon={faEnvelope} />
</Icon>
```