### PR TITLE
change Input props type to HTMLInputElement

### DIFF
--- a/src/elements/Form/Input.tsx
+++ b/src/elements/Form/Input.tsx
@@ -13,7 +13,7 @@ export interface Input<T> extends Bulma.Color, Bulma.Size, Bulma.State,
     React.HTMLProps<T> {
 }
 
-export function Input(props: Input<HTMLElement>) {
+export function Input(props: Input<HTMLInputElement>) {
     const className = classNames(
         'input',
         {


### PR DESCRIPTION
Currently, TypeScript is not able to recognize `event.target.value` in an Input component's `onChange` event. When I changed the typings in node_modules so that the Input props were of type HTMLInputElement, that fixed the issue. I don't know how this codebase works (nor how to test my changes), but I believe this change would fix the problem.